### PR TITLE
Proof output in logs is unicode, marshall instead

### DIFF
--- a/app/api.go
+++ b/app/api.go
@@ -186,15 +186,15 @@ func (api *API) getProofHandler(r *http.Request) (interface{}, error) {
 
 	logging.Logger.Infof("TLOG PUT Response: %s", resp.status)
 
-	// Return TLOG Results as JSON
-	logResults := resp.getProofResult
+	proofResults := resp.getProofResult
+	proofResultsJSON, err := json.Marshal(proofResults)
 
-	logging.Logger.Info("Get Entry Result: ", logResults)
-	logging.Logger.Info(string(api.pubkey.Der))
+	logging.Logger.Info("Return Proof Result: ", string(proofResultsJSON))
+
 	return getProofResponse{
 		ServerResponse: ServerResponse{Status: resp.status},
 		FileRecieved:   FileRecieved{File: header.Filename},
-		Proof:          logResults,
+		Proof:          proofResults,
 		Key:            api.pubkey.Der,
 	}, nil
 


### PR DESCRIPTION
The output is in unicode and so does not give any meaningful
information.

Add a single marshall to convert into readable JSON

Also commented out the pubkey which was being outputted in DER
format. If there is a need to have this shown in the logs, we can
look to decode.

<img width="1409" alt="Screenshot 2020-09-19 at 10 14 25" src="https://user-images.githubusercontent.com/7058938/93663972-6156b480-fa63-11ea-94fc-39265691ffde.png">
