### PR TITLE
Improve status handling and move trillain code into its own file.

### DIFF
--- a/app/api.go
+++ b/app/api.go
@@ -63,8 +63,9 @@ type getProofResponse struct {
 }
 
 type getLeafResponse struct {
-	Leaf *trillian.GetLeavesByIndexResponse
-	Key  []byte
+	Status RespStatusCode
+	Leaf   *trillian.GetLeavesByIndexResponse
+	Key    []byte
 }
 
 type RespStatusCode struct {
@@ -300,8 +301,9 @@ func (api *API) getLeafByIndexHandler(r *http.Request) (interface{}, error) {
 	logging.Logger.Info("Return getLeafByIndex :", string(respJSON))
 
 	return getLeafResponse{
-		Leaf: resp.getLeafByIndexResult,
-		Key:  api.pubkey.Der,
+		Status: RespStatusCode{Code: getGprcCode(resp.status)},
+		Leaf:   resp.getLeafByIndexResult,
+		Key:    api.pubkey.Der,
 	}, nil
 }
 

--- a/app/api.go
+++ b/app/api.go
@@ -43,14 +43,6 @@ type addResponse struct {
 	Status RespStatusCode
 }
 
-type RespStatusCode struct {
-	Code string `json:"status_code"`
-}
-
-type FileRecieved struct {
-	File string `json:"file_recieved"`
-}
-
 type latestResponse struct {
 	Status RespStatusCode
 	Proof  *trillian.GetLatestSignedLogRootResponse
@@ -64,7 +56,7 @@ type getResponse struct {
 }
 
 type getProofResponse struct {
-	Status       RespStatusCode
+	Status       string
 	FileRecieved FileRecieved
 	Proof        *trillian.GetInclusionProofByHashResponse
 	Key          []byte
@@ -159,6 +151,14 @@ func (api *API) getHandler(r *http.Request) (interface{}, error) {
 	}, nil
 }
 
+type RespStatusCode struct {
+	Code string `json:"file_recieved"`
+}
+
+type FileRecieved struct {
+	File string `json:"file_recieved"`
+}
+
 func (api *API) getProofHandler(r *http.Request) (interface{}, error) {
 	file, header, err := r.FormFile("fileupload")
 	if err != nil {
@@ -185,11 +185,9 @@ func (api *API) getProofHandler(r *http.Request) (interface{}, error) {
 	proofResultsJSON, err := json.Marshal(proofResults)
 
 	logging.Logger.Info("Return Proof Result: ", string(proofResultsJSON))
-	grpcResult := RespStatusCode{Code: getGprcCode(resp.status)}
-	logging.Logger.Info((grpcResult))
 
 	return getProofResponse{
-		Status:       grpcResult,
+		Status:       getGprcCode(resp.status),
 		FileRecieved: FileRecieved{File: header.Filename},
 		Proof:        proofResults,
 		Key:          api.pubkey.Der,
@@ -302,7 +300,6 @@ func (api *API) getleafHandler(r *http.Request) (interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	logging.Logger.Info(resp)
 
 	return getLeafResponse{
 		Leaf: resp,

--- a/app/gprc_client.go
+++ b/app/gprc_client.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/projectrekor/rekor-server/logging"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 )
 
 func dial(ctx context.Context, rpcServer string) (*grpc.ClientConn, error) {
@@ -18,4 +19,19 @@ func dial(ctx context.Context, rpcServer string) (*grpc.ClientConn, error) {
 		logging.Logger.Fatalf("Failed to connect to RPC server:", err)
 	}
 	return conn, nil
+}
+
+func getGprcCode(state codes.Code) string {
+	var codeResponse string
+	switch state {
+	case codes.OK:
+		codeResponse = "OK"
+	case codes.NotFound:
+		codeResponse = "Leaf not Found"
+	case codes.AlreadyExists:
+		codeResponse = "Data Already Exists"
+	default:
+		codeResponse = "Error. Unknown Code!"
+	}
+	return codeResponse
 }

--- a/app/gprc_client.go
+++ b/app/gprc_client.go
@@ -22,12 +22,13 @@ func dial(ctx context.Context, rpcServer string) (*grpc.ClientConn, error) {
 }
 
 func getGprcCode(state codes.Code) string {
+	// more entries available here: https://github.com/grpc/grpc-go/blob/e6c98a478e62a717b945eb60edb115faf65215d3/codes/codes.go#L198
 	var codeResponse string
 	switch state {
 	case codes.OK:
 		codeResponse = "OK"
 	case codes.NotFound:
-		codeResponse = "Leaf not Found"
+		codeResponse = "Entry not Found"
 	case codes.AlreadyExists:
 		codeResponse = "Data Already Exists"
 	default:


### PR DESCRIPTION
A number of changes here:

* All trilian functions refactored into `trillian_client.go`
* All functions have GPRC status handler set within `gprc_client.go`
* Rename some functions to make a common naming convention.

This change depends on the following PR being merged in rekor-cli https://github.com/projectrekor/rekor-cli/pull/23