### PR TITLE
improve memory utilization of API endpoints, error checking

### DIFF
--- a/app/api.go
+++ b/app/api.go
@@ -17,10 +17,12 @@ limitations under the License.
 package app
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 
@@ -163,13 +165,16 @@ func (api *API) getHandler(r *http.Request) (interface{}, error) {
 
 	logging.Logger.Info("Received file: ", header.Filename)
 
-	byteLeaf, err := ioutil.ReadAll(file)
-	if err != nil {
+	var byteLeaf bytes.Buffer
+	tee := io.TeeReader(file, &byteLeaf)
+
+	if _, err := types.ParseRekorLeaf(tee); err != nil {
+		logging.Logger.Errorf("Not a valid rekor entry: %s", err)
 		return nil, err
 	}
 
 	server := serverInstance(api.logClient, api.tLogID)
-	resp, err := server.getLeaf(byteLeaf, api.tLogID)
+	resp, err := server.getLeaf(byteLeaf.Bytes(), api.tLogID)
 	if err != nil {
 		return nil, err
 	}
@@ -193,13 +198,20 @@ func (api *API) getProofHandler(r *http.Request) (interface{}, error) {
 
 	logging.Logger.Info("Received file : ", header.Filename)
 
-	byteLeaf, err := ioutil.ReadAll(file)
-	if err != nil {
+	var byteLeaf bytes.Buffer
+	tee := io.TeeReader(file, &byteLeaf)
+
+	leaf, err := types.ParseRekorLeaf(tee)
+	if err != nil || leaf.SHA == "" {
+		if err == nil {
+			err = errors.New("missing SHA sum")
+		}
+		logging.Logger.Errorf("Not a valid rekor entry: %s", err)
 		return nil, err
 	}
 
 	server := serverInstance(api.logClient, api.tLogID)
-	resp, err := server.getProof(byteLeaf, api.tLogID)
+	resp, err := server.getProof(byteLeaf.Bytes(), api.tLogID)
 	if err != nil {
 		return nil, err
 	}
@@ -229,34 +241,47 @@ func (api *API) addHandler(r *http.Request) (interface{}, error) {
 
 	logging.Logger.Info("Received file : ", header.Filename)
 
-	byteLeaf, err := ioutil.ReadAll(file)
-	if err != nil {
-		return nil, err
-	}
+	var byteEntry bytes.Buffer
+	tee := io.TeeReader(file, &byteEntry)
 
-	// See if this is a valid RekorEntry
-	rekorEntry, err := types.ParseRekorEntry(byteLeaf)
+	// See if this is a valid RekorLeaf
+	rekorLeaf, err := types.ParseRekorLeaf(tee)
 	if err != nil {
 		logging.Logger.Errorf("Not a valid rekor entry: %s", err)
 		return nil, err
 	}
-	// Check to see if the entry already exists
+
+	// Check to see if the entry already exists, only if we have a full leaf
 	server := serverInstance(api.logClient, api.tLogID)
-	b, err := rekorEntry.MarshalledLeaf()
+	if rekorLeaf.SHA != "" {
+		byteLeaf, err := json.Marshal(rekorLeaf)
+		if err != nil {
+			return nil, err
+		}
+
+		if resp, err := server.getLeaf(byteLeaf, api.tLogID); err != nil && len(resp.getLeafResult.Leaves) != 0 {
+			return addResponse{
+				Status: RespStatusCode{Code: getGprcCode(codes.AlreadyExists)},
+			}, nil
+		}
+	}
+
+	rekorEntry, err := types.ParseRekorEntry(&byteEntry, *rekorLeaf)
 	if err != nil {
 		return nil, err
 	}
-	if resp, err := server.getLeaf(b, api.tLogID); err != nil && len(resp.getLeafResult.Leaves) != 0 {
-		return addResponse{
-			Status: RespStatusCode{Code: getGprcCode(codes.AlreadyExists)},
-		}, nil
-	}
 
-	// Now load/validate it before entry. This can be expensive, so we first check if the data already exists.
-	if err := rekorEntry.Load(); err != nil {
+	// Now load/validate it before adding. This can be expensive, so we first check if the data already exists.
+	if err := rekorEntry.Load(r.Context()); err != nil {
 		return nil, err
 	}
-	resp, err := server.addLeaf(byteLeaf, api.tLogID)
+
+	leafToAdd, err := json.Marshal(rekorEntry.RekorLeaf)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := server.addLeaf(leafToAdd, api.tLogID)
 	if err != nil {
 		return nil, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/spf13/viper v1.7.1
 	go.uber.org/zap v1.16.0
 	golang.org/x/crypto v0.0.0-20200311171314-f7b00557c8c4
+	golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a
 	google.golang.org/genproto v0.0.0-20200626011028-ee7919e894b5
 	google.golang.org/grpc v1.32.0
 )

--- a/go.sum
+++ b/go.sum
@@ -395,6 +395,7 @@ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20191029031824-8986dd9e96cf/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200311171314-f7b00557c8c4 h1:QmwruyY+bKbDDL0BaglrbZABEali68eoMFhTZpCjYVA=
 golang.org/x/crypto v0.0.0-20200311171314-f7b00557c8c4/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897 h1:pLI5jrR7OSLijeIDcmRxNmw2api+jEfxLoykJVice/E=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
@@ -472,6 +473,7 @@ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a h1:WXEvlFVvvGxCJLG6REjsT03iWnKLEWinaScsxF2Vm2o=
 golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9 h1:SQFwaSi55rU7vdNs9Yr0Z324VNlrF+0wMqRXT4St8ck=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/types/types.go
+++ b/types/types.go
@@ -1,123 +1,30 @@
 package types
 
 import (
+	"bufio"
 	"bytes"
 	"compress/gzip"
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
-	"strings"
 
-	"github.com/projectrekor/rekor-server/logging"
+	"golang.org/x/crypto/openpgp/armor"
+	"golang.org/x/crypto/openpgp/packet"
+
 	"golang.org/x/crypto/openpgp"
+	"golang.org/x/sync/errgroup"
 )
 
 // RekorEntry is the API request.
 type RekorEntry struct {
-	Data []byte
-	SHA  string
-	URL  string
-	// Handle other types than GPG
-	Signature []byte
-	PublicKey []byte
-}
-
-func ParseRekorEntry(b []byte) (*RekorEntry, error) {
-	var e RekorEntry
-	if err := json.Unmarshal(b, &e); err != nil {
-		return nil, err
-	}
-	return &e, nil
-}
-
-func (r *RekorEntry) Load() error {
-	if r.Data == nil && r.URL == "" {
-		return errors.New("one of Contents or ContentsRef must be set")
-	}
-	publicKey, err := openpgp.ReadArmoredKeyRing(bytes.NewReader(r.PublicKey))
-	if err != nil {
-		return fmt.Errorf("error reading public key: %s", err)
-	}
-
-	var dataReader io.Reader
-	if r.URL != "" {
-		resp, err := http.DefaultClient.Get(r.URL)
-		if err != nil {
-			return err
-		}
-
-		defer resp.Body.Close()
-
-		b, err := ioutil.ReadAll(resp.Body)
-		if err != nil {
-			return err
-		}
-
-		logging.Logger.Info("Contents fetched.")
-
-		// Validate the SHA
-		hasher := sha256.New()
-		if strings.HasSuffix(r.URL, ".gz") {
-			logging.Logger.Info("gzipped content detected")
-			gz, err := gzip.NewReader(bytes.NewReader(b))
-			if err != nil {
-				return err
-			}
-			io.Copy(hasher, gz)
-		} else {
-			hasher.Write(b)
-		}
-		sha := hex.EncodeToString(hasher.Sum(nil))
-		if r.SHA != sha {
-			return fmt.Errorf("SHA mismatch: %s", r.SHA)
-		}
-
-		if strings.HasSuffix(r.URL, ".gz") {
-			dataReader, err = gzip.NewReader(dataReader)
-			if err != nil {
-				return err
-			}
-		} else {
-			dataReader = bytes.NewReader(b)
-		}
-	} else {
-		dataReader = bytes.NewReader(r.Data)
-	}
-
-	verifyFn := openpgp.CheckDetachedSignature
-	if strings.Contains(string(r.Signature), "-----BEGIN PGP") {
-		logging.Logger.Info("Armored signature detected")
-		verifyFn = openpgp.CheckArmoredDetachedSignature
-	} else {
-		logging.Logger.Info("Binary signature detected")
-	}
-
-	if _, err := verifyFn(publicKey, dataReader, bytes.NewReader(r.Signature)); err != nil {
-		return err
-	}
-
-	if r.SHA == "" {
-		r.SHA = hex.EncodeToString(sha256.New().Sum(r.Data))
-	}
-
-	return nil
-}
-
-func (r *RekorEntry) Leaf() RekorLeaf {
-	return RekorLeaf{
-		SHA:       r.SHA,
-		Signature: r.Signature,
-		PublicKey: r.PublicKey,
-	}
-}
-
-func (r *RekorEntry) MarshalledLeaf() ([]byte, error) {
-	return json.Marshal(r.Leaf())
+	Data      []byte
+	URL       string
+	RekorLeaf `json:"-"`
 }
 
 // RekorLeaf is the type we store in the log.
@@ -125,4 +32,195 @@ type RekorLeaf struct {
 	SHA       string
 	Signature []byte
 	PublicKey []byte
+	PubKeyEnt openpgp.EntityList `json:"-"`
+	ArmorSig  bool               `json:"-"`
+}
+
+func ParseRekorLeaf(r io.Reader) (*RekorLeaf, error) {
+	var l RekorLeaf
+	dec := json.NewDecoder(r)
+	if err := dec.Decode(&l); err != nil && err != io.EOF {
+		return nil, err
+	}
+
+	// validate fields
+	if l.SHA != "" {
+		if _, err := hex.DecodeString(l.SHA); err != nil || len(l.SHA) != 64 {
+			return nil, fmt.Errorf("Invalid SHA hash provided")
+		}
+	}
+
+	// check if this is an actual signature
+	var sigReader io.Reader
+	sigByteReader := bytes.NewReader(l.Signature)
+	sigBlock, err := armor.Decode(sigByteReader)
+	if err == nil {
+		l.ArmorSig = true
+		if sigBlock.Type != openpgp.SignatureType {
+			return nil, fmt.Errorf("Invalid signature provided")
+		}
+		sigReader = sigBlock.Body
+	} else {
+		l.ArmorSig = false
+		if _, err := sigByteReader.Seek(0, io.SeekStart); err != nil {
+			return nil, err
+		}
+		sigReader = sigByteReader
+	}
+	sigPktReader := packet.NewReader(sigReader)
+	sigPkt, err := sigPktReader.Next()
+	if err != nil {
+		return nil, fmt.Errorf("Invalid signature provided")
+	}
+	if _, ok := sigPkt.(*packet.Signature); ok != true {
+		if _, ok := sigPkt.(*packet.SignatureV3); ok != true {
+			return nil, fmt.Errorf("Invalid signature provided")
+		}
+	}
+
+	// check if this is an actual public key
+	var keyReader io.Reader
+	keyByteReader := bytes.NewReader(l.PublicKey)
+	keyBlock, err := armor.Decode(keyByteReader)
+	if err == nil {
+		if keyBlock.Type != openpgp.PublicKeyType {
+			return nil, fmt.Errorf("Invalid public key provided")
+		}
+		keyReader = keyBlock.Body
+	} else {
+		if _, err := keyByteReader.Seek(0, io.SeekStart); err != nil {
+			return nil, err
+		}
+		keyReader = keyByteReader
+	}
+
+	pubKey, err := openpgp.ReadKeyRing(keyReader)
+	if err != nil {
+		return nil, fmt.Errorf("Invalid public key provided")
+	}
+	l.PubKeyEnt = pubKey
+
+	return &l, nil
+}
+
+func ParseRekorEntry(r io.Reader, leaf RekorLeaf) (*RekorEntry, error) {
+	var e RekorEntry
+	dec := json.NewDecoder(r)
+	if err := dec.Decode(&e); err != nil && err != io.EOF {
+		return nil, err
+	}
+	//decode above should not have included the previously parsed & validated leaf, so copy it in
+	e.RekorLeaf = leaf
+
+	if e.Data == nil && e.URL == "" {
+		return nil, errors.New("one of Contents or ContentsRef must be set")
+	}
+
+	if e.URL != "" && e.SHA == "" {
+		return nil, errors.New("SHA hash must be specified if URL is set")
+	}
+
+	return &e, nil
+}
+
+func (r *RekorEntry) Load(ctx context.Context) error {
+
+	hashR, hashW := io.Pipe()
+	pgpR, pgpW := io.Pipe()
+
+	var dataReader io.Reader
+	if r.URL != "" {
+		//TODO: set timeout here, SSL settings?
+		resp, err := http.DefaultClient.Get(r.URL)
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+
+		// read first 512 bytes to determine if content is gzip compressed
+		bufReader := bufio.NewReaderSize(resp.Body, 512)
+		ctBuf, err := bufReader.Peek(512)
+		if err != nil && err != bufio.ErrBufferFull && err != io.EOF {
+			return err
+		}
+
+		if "application/x+gzip" == http.DetectContentType(ctBuf) {
+			dataReader, _ = gzip.NewReader(io.MultiReader(bufReader, resp.Body))
+		} else {
+			dataReader = io.MultiReader(bufReader, resp.Body)
+		}
+	} else {
+		dataReader = bytes.NewReader(r.Data)
+	}
+
+	g, ctx := errgroup.WithContext(ctx)
+
+	g.Go(func() error {
+		defer hashW.Close()
+		defer pgpW.Close()
+
+		/* #nosec G110 */
+		if _, err := io.Copy(io.MultiWriter(hashW, pgpW), dataReader); err != nil {
+			return err
+		}
+		return nil
+	})
+
+	hashResult := make(chan string)
+
+	g.Go(func() error {
+		defer hashR.Close()
+		defer close(hashResult)
+
+		hasher := sha256.New()
+
+		if _, err := io.Copy(hasher, hashR); err != nil {
+			return err
+		}
+
+		computedSHA := hex.EncodeToString(hasher.Sum(nil))
+		if r.SHA != "" && computedSHA != r.SHA {
+			return fmt.Errorf("SHA mismatch: %s != %s", computedSHA, r.SHA)
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case hashResult <- computedSHA:
+			return nil
+		}
+	})
+
+	g.Go(func() error {
+		defer pgpR.Close()
+
+		verifyFn := openpgp.CheckDetachedSignature
+		if r.ArmorSig == true {
+			verifyFn = openpgp.CheckArmoredDetachedSignature
+		}
+
+		if _, err := verifyFn(r.PubKeyEnt, pgpR, bytes.NewReader(r.Signature)); err != nil {
+			return err
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+			return nil
+		}
+	})
+
+	computedSHA := <-hashResult
+
+	if err := g.Wait(); err != nil {
+		return err
+	}
+
+	// if we get here, all goroutines succeeded without error
+	if r.SHA == "" {
+		r.SHA = computedSHA
+	}
+
+	return nil
 }


### PR DESCRIPTION
this change includes several optimizations to minimize the memory footprint
of the rekor-server, including:

- validating input signature, public key, SHA values are valid before CPU &
memory intensive operations occur before inserting leaf into tLOG
- minimizing or removing copies of data in memory where possible
- parallelize hash computation & signature validation for remote fetch
- detect content-type for remote resource to determine if gzip is needed,
instead of relying on file extension

@dlorenc @lukehinds please take a look and let me know any early thoughts. 