### PR TITLE
Add request ID to HTTP handler logs

### DIFF
--- a/logging/logging.go
+++ b/logging/logging.go
@@ -17,7 +17,11 @@ limitations under the License.
 package logging
 
 import (
+	"context"
 	"log"
+	"net/http"
+
+	"github.com/go-chi/chi/middleware"
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -34,4 +38,18 @@ func createGlobalLogger() *zap.SugaredLogger {
 	}
 
 	return logger.Sugar()
+}
+
+func WithRequestID(ctx context.Context, id string) context.Context {
+	return context.WithValue(ctx, middleware.RequestIDKey, id)
+}
+
+func RequestIDLogger(r *http.Request) *zap.SugaredLogger {
+	proposedLogger := Logger
+	if r != nil {
+		if ctxRequestID, ok := r.Context().Value(middleware.RequestIDKey).(string); ok {
+			proposedLogger = proposedLogger.With(zap.String("requestID", ctxRequestID))
+		}
+	}
+	return proposedLogger
 }


### PR DESCRIPTION
In order to aid debugging, create new logger that appends a request
ID to log messages that are generated in the context of a HTTP
handler. This allows logs to be filtered for a particular request,
especially helpful when you have multiple concurrent requests being
processed.

@dlorenc @lukehinds 