### PR TITLE
fix gosec issues due to no error checking

### DIFF
--- a/app/api.go
+++ b/app/api.go
@@ -83,7 +83,7 @@ type FileRecieved struct {
 func NewAPI() (*API, error) {
 	logRpcServer := fmt.Sprintf("%s:%d",
 		viper.GetString("trillian_log_server.address"),
-		viper.GetInt("trillian_log_server.port"))
+		viper.GetUint("trillian_log_server.port"))
 	ctx := context.Background()
 	tConn, err := dial(ctx, logRpcServer)
 	if err != nil {
@@ -103,7 +103,7 @@ func NewAPI() (*API, error) {
 
 	mapRpcServer := fmt.Sprintf("%s:%d",
 		viper.GetString("trillian_map_server.address"),
-		viper.GetInt("trillian_map_server.port"))
+		viper.GetUint("trillian_map_server.port"))
 	mConn, err := dial(ctx, mapRpcServer)
 	if err != nil {
 		return nil, err

--- a/app/server.go
+++ b/app/server.go
@@ -41,7 +41,7 @@ func NewServer() (*Server, error) {
 
 	addr := fmt.Sprintf("%s:%d",
 		viper.GetString("rekor_server.address"),
-		viper.GetInt("rekor_server.port"))
+		viper.GetUint("rekor_server.port"))
 
 	srv := http.Server{
 		Addr:    addr,

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -58,20 +58,15 @@ func init() {
 
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.rekor-server.yaml)")
 
-	flags := [][3]string{
-		{"trillian_log_server.address", "127.0.0.1", "Server address"},
-		{"trillian_log_server.port", "8091", "Server port"},
-		{"trillian_map_server.address", "127.0.0.1", "Server address"},
-		{"trillian_map_server.port", "8093", "Server port"},
-		{"rekor_server.address", "127.0.0.1", "Server address"},
-		{"rekor_server.port", "3000", "Server port"},
-	}
+	rootCmd.PersistentFlags().String("trillian_log_server.address", "127.0.0.1", "Trillian log server address")
+	rootCmd.PersistentFlags().Uint16("trillian_log_server.port", 8091, "Trillian log server port")
+	rootCmd.PersistentFlags().String("trillian_map_server.address", "127.0.0.1", "Trillian map server address")
+	rootCmd.PersistentFlags().Uint16("trillian_map_server.port", 8093, "Trillian map server port")
+	rootCmd.PersistentFlags().String("rekor_server.address", "127.0.0.1", "Address to bind to")
+	rootCmd.PersistentFlags().Uint16("rekor_server.port", 3000, "Port to bind to")
 
-	for _, flag := range flags {
-		rootCmd.PersistentFlags().String(flag[0], flag[1], flag[2])
-		if err := viper.BindPFlag(flag[0], rootCmd.PersistentFlags().Lookup(flag[0])); err != nil {
-			logging.Logger.Fatal(err)
-		}
+	if err := viper.BindPFlags(rootCmd.PersistentFlags()); err != nil {
+		logging.Logger.Fatal(err)
 	}
 
 	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -58,20 +58,21 @@ func init() {
 
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.rekor-server.yaml)")
 
-	rootCmd.PersistentFlags().String("trillian_log_server.address", "127.0.0.1", "Server address")
-	viper.BindPFlag("trillian_log_server.address", rootCmd.PersistentFlags().Lookup("trillian_log_server.address"))
-	rootCmd.PersistentFlags().String("trillian_log_server.port", "8091", "Server port")
-	viper.BindPFlag("trillian_log_server.port", rootCmd.PersistentFlags().Lookup("trillian_log_server.port"))
+	flags := [][3]string{
+		{"trillian_log_server.address", "127.0.0.1", "Server address"},
+		{"trillian_log_server.port", "8091", "Server port"},
+		{"trillian_map_server.address", "127.0.0.1", "Server address"},
+		{"trillian_map_server.port", "8093", "Server port"},
+		{"rekor_server.address", "127.0.0.1", "Server address"},
+		{"rekor_server.port", "3000", "Server port"},
+	}
 
-	rootCmd.PersistentFlags().String("trillian_map_server.address", "127.0.0.1", "Server address")
-	viper.BindPFlag("trillian_map_server.address", rootCmd.PersistentFlags().Lookup("trillian_map_server.address"))
-	rootCmd.PersistentFlags().String("trillian_map_server.port", "8093", "Server port")
-	viper.BindPFlag("trillian_map_server.port", rootCmd.PersistentFlags().Lookup("trillian_map_server.port"))
-
-	rootCmd.PersistentFlags().String("rekor_server.address", "127.0.0.1", "Server address")
-	viper.BindPFlag("rekor_server.address", rootCmd.PersistentFlags().Lookup("rekor_server.address"))
-	rootCmd.PersistentFlags().String("rekor_server.port", "3000", "Server port")
-	viper.BindPFlag("rekor_server.port", rootCmd.PersistentFlags().Lookup("rekor_server.port"))
+	for _, flag := range flags {
+		rootCmd.PersistentFlags().String(flag[0], flag[1], flag[2])
+		if err := viper.BindPFlag(flag[0], rootCmd.PersistentFlags().Lookup(flag[0])); err != nil {
+			logging.Logger.Fatal(err)
+		}
+	}
 
 	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }


### PR DESCRIPTION
Gosec was complaining that the error from viper.BPFlag was not being checked;
this patch fixes that issue and iterates over an array instead of individual
calls per flag.